### PR TITLE
Fixed ordering of lookup for types 

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -75,6 +75,11 @@ version = "0.4.3"
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
+[[OrderedCollections]]
+git-tree-sha1 = "293b70ac1780f9584c89268a6e2a560d938a7065"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "1.3.0"
+
 [[Parsers]]
 deps = ["Dates", "Test"]
 git-tree-sha1 = "8077624b3c450b15c087944363606a6ba12f925e"

--- a/Project.toml
+++ b/Project.toml
@@ -7,10 +7,12 @@ version = "2.0.0"
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 Mmap = "a63ad114-7e13-5084-954f-fe012c677804"
+OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
+OrderedCollections = "1.3"
 CategoricalArrays = "0.8"
 JSON3 = "1.1"
 StructTypes = "1.1"

--- a/README.md
+++ b/README.md
@@ -4,13 +4,19 @@
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://danielw2904.github.io/JSONLines.jl/dev)
 [![Build Status](https://github.com/danielw2904/JSONLines.jl/workflows/CI/badge.svg)](https://github.com/danielw2904/JSONLines.jl/actions)
 
-A simple package to read (parts of) a [JSON Lines](http://jsonlines.org/) files to a vector of `JSON3.Object`s and write rows to a JSON Lines file. This vector is `Tables.jl` compatible and can directly be piped into e.g. a DataFrame if every row in the result has the same schema (i.e. the same variables). It allows memory-efficient loading of rows of a JSON Lines file. In order to select the rows `skip` and `nrows` can be used to load `nrows` rows after skipping `skip` rows. The file is `mmap`ed and only the required rows are loaded into RAM. Files must contain a valid JSON object (denoted by `{"String1":ELEMENT1, "String2":ELEMENT2, ...}`) on each line. JSON parsing is done using the [JSON3.jl](https://github.com/quinnj/JSON3.jl) package. Lines can be separated by `\n` or `\r\n` and some whitespace characters are allowed between the end of the JSON object and the newline character (basically all that can be represented as a single `UInt8`). Typically a file would look like this:
-
-
+A simple package to read (parts of) a [JSON Lines](http://jsonlines.org/) files. The main purpose is to read files that are larger than memory. The two main functions are `LineIndex` and `LineIterator` which return an index of the rows in the given file and an iterator over the file, respectively. The `LineIndex` is `Tables.jl` compatible and can directly be piped into e.g. a DataFrame if every row in the result has the same schema (i.e. the same variables). See also `materialize` and `columnwise`. It allows memory-efficient loading of rows of a JSON Lines file. In order to select the rows `skip` and `nrows` can be used to index `nrows` rows after skipping `skip` rows. The file is `mmap`ed and only the required rows are loaded into RAM. Files must contain a valid JSON object (denoted by `{"String1":ELEMENT1, "String2":ELEMENT2, ...}`) on each line. JSON parsing is done using the [JSON3.jl](https://github.com/quinnj/JSON3.jl) package. Lines can be separated by `\n` or `\r\n` and some whitespace characters are allowed at the beginning of a line before the JSON object and the newline character (basically all that can be represented as a single `UInt8`). Typically a file would look like this: 
 ```
 {"name":"Daniel","organization":"IMSM"}
 {"name":"Peter","organization":"StatMath"}
 ```
+
+There is experimental support for JSON Arrays on each line where the first line after skip contains the names of the columns.
+```
+["name", "organization"]
+["Daniel", "IMSM"]
+["Peter", "StatMath]
+```
+This **should** work but is not tested thoroughly. Please report any usecase that is not working.
 
 # Getting Started
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,11 +4,19 @@ CurrentModule = JSONLines
 
 # JSONLines
 
-A simple package to read (parts of) a [JSON Lines](http://jsonlines.org/) files to a vector of `JSON3.Object`s. This vector is `Tables.jl` compatible and can directly be piped into e.g. a DataFrame if every row in the result has the same schema (i.e. the same variables). It allows memory-efficient loading of rows of a JSON Lines file. In order to select the rows `skip` and `nrows` can be used to load `nrows` rows after skipping `skip` rows. The file is `mmap`ed and only the required rows are loaded into RAM. Files must contain a valid JSON object (denoted by `{"String1":ELEMENT1, "String2":ELEMENT2, ...}`) on each line. JSON parsing is done using the [JSON3.jl](https://github.com/quinnj/JSON3.jl) package. Lines can be separated by `\n` or `\r\n` and some whitespace characters are allowed between the end of the JSON object and the newline character (basically all that can be represented as a single `UInt8`). Typically a file would look like this: 
+A simple package to read (parts of) a [JSON Lines](http://jsonlines.org/) files. The main purpose is to read files that are larger than memory. The two main functions are `LineIndex` and `LineIterator` which return an index of the rows in the given file and an iterator over the file, respectively. The `LineIndex` is `Tables.jl` compatible and can directly be piped into e.g. a DataFrame if every row in the result has the same schema (i.e. the same variables). See also `materialize` and `columnwise`. It allows memory-efficient loading of rows of a JSON Lines file. In order to select the rows `skip` and `nrows` can be used to index `nrows` rows after skipping `skip` rows. The file is `mmap`ed and only the required rows are loaded into RAM. Files must contain a valid JSON object (denoted by `{"String1":ELEMENT1, "String2":ELEMENT2, ...}`) on each line. JSON parsing is done using the [JSON3.jl](https://github.com/quinnj/JSON3.jl) package. Lines can be separated by `\n` or `\r\n` and some whitespace characters are allowed at the beginning of a line before the JSON object and the newline character (basically all that can be represented as a single `UInt8`). Typically a file would look like this: 
 ```
 {"name":"Daniel","organization":"IMSM"}
 {"name":"Peter","organization":"StatMath"}
 ```
+
+There is experimental support for JSON Arrays on each line where the first line after skip contains the names of the columns.
+```
+["name", "organization"]
+["Daniel", "IMSM"]
+["Peter", "StatMath]
+```
+This **should** work but is not tested thoroughly.
 
 # Getting Started
 

--- a/src/JSONLines.jl
+++ b/src/JSONLines.jl
@@ -31,6 +31,9 @@ import Tables:
     istable,
     rowaccess,
     rows
+
+import OrderedCollections:
+    OrderedDict
     
 export writelines,
     @MStructType,

--- a/src/LineIndex.jl
+++ b/src/LineIndex.jl
@@ -7,7 +7,7 @@ struct LineIndex{T}
     names::Vector{Symbol}
     lookup::Union{Dict{Int, Symbol}, Dict{Symbol, Int}}
     rowtype::Union{DataType, UnionAll}
-    columntypes::Dict{Symbol, Union{DataType, UnionAll, Union}}
+    columntypes::OrderedDict{Symbol, Union{DataType, UnionAll, Union}}
     structtype::Union{Nothing, DataType}
     nworkers::Int
 end
@@ -36,7 +36,7 @@ function LineIndex(buf::Vector{UInt8}, filestart::Int = 0, skip::Int = 0, nrows:
         lookup = Dict(names .=> 1:length(names))
         typelookup = Dict{Symbol, DataType}() # TODO Implement checking
     else
-        typelookup = Dict{Symbol, Union{DataType, UnionAll}}()
+        typelookup = OrderedDict{Symbol, Union{DataType, UnionAll}}()
         lookup = Dict{Int, Symbol}()
         checkrows = (length(lineindex)-1) > last(schemafrom) ? schemafrom : first(schemafrom):(length(lineindex)-1)
         names = Symbol[]
@@ -56,8 +56,6 @@ function LineIndex(buf::Vector{UInt8}, filestart::Int = 0, skip::Int = 0, nrows:
                 end
             end
         end
-       # names = collect(keys(typelookup))
-#        lookup = Dict(1:length(names) .=> names)
     end
     return LineIndex{rowtype}(buf, filestart, fileend, lineindex, names, lookup, rowtype, typelookup, structtype, nworkers) 
 end

--- a/src/LineIndex.jl
+++ b/src/LineIndex.jl
@@ -17,7 +17,7 @@ function LineIndex(buf::Vector{UInt8}, filestart::Int = 0, skip::Int = 0, nrows:
     filestart = skip > 0 ? skiprows(buf, fileend, skip, filestart) : filestart
     if filestart == fileend 
         @warn "Skipped all lines"
-        return LineIndex{Missing}(buf, filestart, fileend, Int[0], Symbol[], Dict{Int, Symbol}(),  UnionAll, Dict{Symbol, Union{DataType, UnionAll}}(), nothing, nworkers)
+        return LineIndex{Missing}(buf, filestart, fileend, Int[0], Symbol[], Dict{Int, Symbol}(),  UnionAll, OrderedDict{Symbol, Union{DataType, UnionAll}}(), nothing, nworkers)
     end
     if nworkers > 1
         # Todo issue warning about nrows being ignored
@@ -34,7 +34,7 @@ function LineIndex(buf::Vector{UInt8}, filestart::Int = 0, skip::Int = 0, nrows:
         lineindex = lineindex[2:end]
         row = parserow(@inbounds(@view(buf[rowindex(lineindex, 1)])), structtype)
         lookup = Dict(names .=> 1:length(names))
-        typelookup = Dict{Symbol, DataType}() # TODO Implement checking
+        typelookup = OrderedDict{Symbol, DataType}() # TODO Implement checking
     else
         typelookup = OrderedDict{Symbol, Union{DataType, UnionAll}}()
         lookup = Dict{Int, Symbol}()

--- a/src/sugar.jl
+++ b/src/sugar.jl
@@ -33,9 +33,9 @@ macro select(path::String, nworkers, vars...)
 end
 
 """
-    select(jsonlines, cols...) => LineIndex
+    select(path::String, cols...; nworkers = 1) => LineIndex
 
-* `jsonlines`: Iterator over unparsed JSONLines (e.g. readlazy("file.jsonlines", returnparsed = false))
+* `path`: Path to JSONLines file 
 * `cols...`: Columnnames to be selected
 * Keyword Argument:
     * `nworkers=1`: Number of threads to use for operations on the resulting LineIndex

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -258,7 +258,7 @@ function _columnwise(lines, coltypes)
     # Add rows
     for (i, row) in enumerate(lines)
         rnames = propertynames(row)
-        # Add columns
+        # Add values 
         for name in rnames
             # Known columns
             if haskey(lookup, name)
@@ -278,7 +278,7 @@ function _columnwise(lines, coltypes)
            columns[lookup[name]][i] = missing
         end # for mnames
     end # for lines
-    fcolnames = collect(keys(lookup))
+    fcolnames = sort(collect(keys(lookup)), by = k -> lookup[k])
     if !isnothing(coltypes)
         untyped = filter(x -> x ∉ collect(keys(coltypes)), fcolnames)
     else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -168,8 +168,8 @@ end
 end
 
 @testset "Columnwise" begin
-    mt_cur = LineIndex("testfiles/mtcars.jsonl", nrows = nrow_mt) |> columnwise |> DataFrame 
-    @test mt_cur.mpg == noprom_mtcars.mpg
+    mt_cur = LineIndex("testfiles/mtcars.jsonl")
+    @test columnwise(mt_cur).mpg == noprom_mtcars.mpg
 end
 
 @testset "Filter" begin


### PR DESCRIPTION
this makes `columnwise` return in "correct" order